### PR TITLE
一覧表示の画面の大枠作成＋app.dartの微修正

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pokemon_app/feature/base/base_screen.dart';
 
 class App extends ConsumerWidget {
   const App({super.key});
@@ -7,12 +8,11 @@ class App extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'pokemon-app',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const SizedBox.shrink(),
+      home: const BaseScreen(),
     );
   }
 }

--- a/lib/feature/base/base_screen.dart
+++ b/lib/feature/base/base_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class BaseScreen extends StatelessWidget {
+  const BaseScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pokemon app'),
+        backgroundColor: Colors.amber,
+        actions: [
+          IconButton(
+            color: Colors.red,
+            onPressed: () {},
+            icon: const Icon(Icons.favorite),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# 概要

- `base.dart`を作成し一覧表示を行う画面の大枠を作成
- app.dratの修正
    - home:に`baseScreen`を 渡すように
    - titleを修正

# スクリーンショット (UI の追加、変更時に添付)

<img width="261" alt="Screenshot 2024-03-13 at 10 31 35" src="https://github.com/yyupyong/pokemon-app/assets/109585930/65567c9e-3920-4075-8fb6-2203e8b583e1">

# チェックリスト　

※ 実行したら x と記載し、当てはまらない場合は　 NA と記載する

- [x] Github 上でコードを確認して、コードが適切であることを確認した
- [x] Github 上でコードを確認して、不要な変更が含まれていないことを確認した
- [NA] 必要な箇所に `TODO`, `FIXME`を付けて、チケット ID を書いた
