### PR TITLE
ポケモンの詳細データクラスとfetchするproviderを作成

### DIFF
--- a/lib/feature/base/base_screen.dart
+++ b/lib/feature/base/base_screen.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pokemon_app/feature/base/pokemon_fetch.dart';
 import 'package:pokemon_app/gen/assets.gen.dart';
 
-class BaseScreen extends StatelessWidget {
+class BaseScreen extends ConsumerWidget {
   const BaseScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pokemonList = ref.watch(fetchPokemonListProvider);
+
     return Scaffold(
       body: Stack(
         children: [
@@ -14,37 +18,47 @@ class BaseScreen extends StatelessWidget {
             child: Assets.monsterBallGray
                 .image(width: 160, height: 160, fit: BoxFit.cover),
           ),
-          CustomScrollView(
-            slivers: [
-              SliverPadding(
-                padding: EdgeInsets.only(
-                  top: MediaQuery.of(context).padding.top + 24,
-                  left: 16,
-                ),
-                sliver: const SliverToBoxAdapter(
-                  child: Text(
-                    'Pokemon',
-                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.w800),
+          pokemonList.maybeWhen(
+            orElse: () => const Center(
+              child: CircularProgressIndicator(),
+            ),
+            data: (data) {
+              return CustomScrollView(
+                slivers: [
+                  SliverPadding(
+                    padding: EdgeInsets.only(
+                      top: MediaQuery.of(context).padding.top + 24,
+                      left: 16,
+                    ),
+                    sliver: const SliverToBoxAdapter(
+                      child: Text(
+                        'Pokemon',
+                        style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ),
                   ),
-                ),
-              ),
-              SliverPadding(
-                padding: const EdgeInsets.only(
-                  top: 24,
-                  left: 16,
-                ),
-                sliver: SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    childCount: 10,
-                    (context, index) {
-                      return Text(
-                        index.toString(),
-                      );
-                    },
+                  SliverPadding(
+                    padding: const EdgeInsets.only(
+                      top: 24,
+                      left: 16,
+                    ),
+                    sliver: SliverList(
+                      delegate: SliverChildBuilderDelegate(
+                        childCount: data.items.length,
+                        (context, index) {
+                          return Text(
+                            data.items[index].name,
+                          );
+                        },
+                      ),
+                    ),
                   ),
-                ),
-              ),
-            ],
+                ],
+              );
+            },
           ),
         ],
       ),

--- a/lib/feature/base/model/pokemon.dart
+++ b/lib/feature/base/model/pokemon.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pokemon.freezed.dart';
+part 'pokemon.g.dart';
+
+@freezed
+class Pokemon with _$Pokemon {
+  const factory Pokemon({
+    required String name,
+    required String url,
+  }) = _Pokemon;
+
+  factory Pokemon.fromJson(Map<String, dynamic> json) =>
+      _$PokemonFromJson(json);
+}

--- a/lib/feature/base/model/pokemon.freezed.dart
+++ b/lib/feature/base/model/pokemon.freezed.dart
@@ -1,0 +1,164 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'pokemon.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Pokemon _$PokemonFromJson(Map<String, dynamic> json) {
+  return _Pokemon.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Pokemon {
+  String get name => throw _privateConstructorUsedError;
+  String get url => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PokemonCopyWith<Pokemon> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PokemonCopyWith<$Res> {
+  factory $PokemonCopyWith(Pokemon value, $Res Function(Pokemon) then) =
+      _$PokemonCopyWithImpl<$Res, Pokemon>;
+  @useResult
+  $Res call({String name, String url});
+}
+
+/// @nodoc
+class _$PokemonCopyWithImpl<$Res, $Val extends Pokemon>
+    implements $PokemonCopyWith<$Res> {
+  _$PokemonCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? url = null,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PokemonImplCopyWith<$Res> implements $PokemonCopyWith<$Res> {
+  factory _$$PokemonImplCopyWith(
+          _$PokemonImpl value, $Res Function(_$PokemonImpl) then) =
+      __$$PokemonImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String name, String url});
+}
+
+/// @nodoc
+class __$$PokemonImplCopyWithImpl<$Res>
+    extends _$PokemonCopyWithImpl<$Res, _$PokemonImpl>
+    implements _$$PokemonImplCopyWith<$Res> {
+  __$$PokemonImplCopyWithImpl(
+      _$PokemonImpl _value, $Res Function(_$PokemonImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? url = null,
+  }) {
+    return _then(_$PokemonImpl(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PokemonImpl implements _Pokemon {
+  const _$PokemonImpl({required this.name, required this.url});
+
+  factory _$PokemonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PokemonImplFromJson(json);
+
+  @override
+  final String name;
+  @override
+  final String url;
+
+  @override
+  String toString() {
+    return 'Pokemon(name: $name, url: $url)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PokemonImpl &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.url, url) || other.url == url));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, name, url);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PokemonImplCopyWith<_$PokemonImpl> get copyWith =>
+      __$$PokemonImplCopyWithImpl<_$PokemonImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PokemonImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Pokemon implements Pokemon {
+  const factory _Pokemon(
+      {required final String name, required final String url}) = _$PokemonImpl;
+
+  factory _Pokemon.fromJson(Map<String, dynamic> json) = _$PokemonImpl.fromJson;
+
+  @override
+  String get name;
+  @override
+  String get url;
+  @override
+  @JsonKey(ignore: true)
+  _$$PokemonImplCopyWith<_$PokemonImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/feature/base/model/pokemon.g.dart
+++ b/lib/feature/base/model/pokemon.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pokemon.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PokemonImpl _$$PokemonImplFromJson(Map<String, dynamic> json) =>
+    _$PokemonImpl(
+      name: json['name'] as String,
+      url: json['url'] as String,
+    );
+
+Map<String, dynamic> _$$PokemonImplToJson(_$PokemonImpl instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'url': instance.url,
+    };

--- a/lib/feature/base/model/pokemon_detail.dart
+++ b/lib/feature/base/model/pokemon_detail.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pokemon_detail.freezed.dart';
+part 'pokemon_detail.g.dart';
+
+@freezed
+class PokemonDetail with _$PokemonDetail {
+  const factory PokemonDetail({
+    required int id,
+    required int height,
+    required int weight,
+    required List<Map<String, Object?>> stats,
+  }) = _PokemonDetail;
+
+  factory PokemonDetail.fromJson(Map<String, dynamic> json) =>
+      _$PokemonDetailFromJson(json);
+}

--- a/lib/feature/base/model/pokemon_detail.freezed.dart
+++ b/lib/feature/base/model/pokemon_detail.freezed.dart
@@ -1,0 +1,214 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'pokemon_detail.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PokemonDetail _$PokemonDetailFromJson(Map<String, dynamic> json) {
+  return _PokemonDetail.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PokemonDetail {
+  int get id => throw _privateConstructorUsedError;
+  int get height => throw _privateConstructorUsedError;
+  int get weight => throw _privateConstructorUsedError;
+  List<Map<String, Object?>> get stats => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PokemonDetailCopyWith<PokemonDetail> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PokemonDetailCopyWith<$Res> {
+  factory $PokemonDetailCopyWith(
+          PokemonDetail value, $Res Function(PokemonDetail) then) =
+      _$PokemonDetailCopyWithImpl<$Res, PokemonDetail>;
+  @useResult
+  $Res call({int id, int height, int weight, List<Map<String, Object?>> stats});
+}
+
+/// @nodoc
+class _$PokemonDetailCopyWithImpl<$Res, $Val extends PokemonDetail>
+    implements $PokemonDetailCopyWith<$Res> {
+  _$PokemonDetailCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? height = null,
+    Object? weight = null,
+    Object? stats = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      height: null == height
+          ? _value.height
+          : height // ignore: cast_nullable_to_non_nullable
+              as int,
+      weight: null == weight
+          ? _value.weight
+          : weight // ignore: cast_nullable_to_non_nullable
+              as int,
+      stats: null == stats
+          ? _value.stats
+          : stats // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, Object?>>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PokemonDetailImplCopyWith<$Res>
+    implements $PokemonDetailCopyWith<$Res> {
+  factory _$$PokemonDetailImplCopyWith(
+          _$PokemonDetailImpl value, $Res Function(_$PokemonDetailImpl) then) =
+      __$$PokemonDetailImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int id, int height, int weight, List<Map<String, Object?>> stats});
+}
+
+/// @nodoc
+class __$$PokemonDetailImplCopyWithImpl<$Res>
+    extends _$PokemonDetailCopyWithImpl<$Res, _$PokemonDetailImpl>
+    implements _$$PokemonDetailImplCopyWith<$Res> {
+  __$$PokemonDetailImplCopyWithImpl(
+      _$PokemonDetailImpl _value, $Res Function(_$PokemonDetailImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? height = null,
+    Object? weight = null,
+    Object? stats = null,
+  }) {
+    return _then(_$PokemonDetailImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      height: null == height
+          ? _value.height
+          : height // ignore: cast_nullable_to_non_nullable
+              as int,
+      weight: null == weight
+          ? _value.weight
+          : weight // ignore: cast_nullable_to_non_nullable
+              as int,
+      stats: null == stats
+          ? _value._stats
+          : stats // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, Object?>>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PokemonDetailImpl implements _PokemonDetail {
+  const _$PokemonDetailImpl(
+      {required this.id,
+      required this.height,
+      required this.weight,
+      required final List<Map<String, Object?>> stats})
+      : _stats = stats;
+
+  factory _$PokemonDetailImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PokemonDetailImplFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final int height;
+  @override
+  final int weight;
+  final List<Map<String, Object?>> _stats;
+  @override
+  List<Map<String, Object?>> get stats {
+    if (_stats is EqualUnmodifiableListView) return _stats;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_stats);
+  }
+
+  @override
+  String toString() {
+    return 'PokemonDetail(id: $id, height: $height, weight: $weight, stats: $stats)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PokemonDetailImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.height, height) || other.height == height) &&
+            (identical(other.weight, weight) || other.weight == weight) &&
+            const DeepCollectionEquality().equals(other._stats, _stats));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, height, weight,
+      const DeepCollectionEquality().hash(_stats));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PokemonDetailImplCopyWith<_$PokemonDetailImpl> get copyWith =>
+      __$$PokemonDetailImplCopyWithImpl<_$PokemonDetailImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PokemonDetailImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PokemonDetail implements PokemonDetail {
+  const factory _PokemonDetail(
+      {required final int id,
+      required final int height,
+      required final int weight,
+      required final List<Map<String, Object?>> stats}) = _$PokemonDetailImpl;
+
+  factory _PokemonDetail.fromJson(Map<String, dynamic> json) =
+      _$PokemonDetailImpl.fromJson;
+
+  @override
+  int get id;
+  @override
+  int get height;
+  @override
+  int get weight;
+  @override
+  List<Map<String, Object?>> get stats;
+  @override
+  @JsonKey(ignore: true)
+  _$$PokemonDetailImplCopyWith<_$PokemonDetailImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/feature/base/model/pokemon_detail.g.dart
+++ b/lib/feature/base/model/pokemon_detail.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pokemon_detail.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PokemonDetailImpl _$$PokemonDetailImplFromJson(Map<String, dynamic> json) =>
+    _$PokemonDetailImpl(
+      id: json['id'] as int,
+      height: json['height'] as int,
+      weight: json['weight'] as int,
+      stats: (json['stats'] as List<dynamic>)
+          .map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$$PokemonDetailImplToJson(_$PokemonDetailImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'height': instance.height,
+      'weight': instance.weight,
+      'stats': instance.stats,
+    };

--- a/lib/feature/base/pokemon_fetch.dart
+++ b/lib/feature/base/pokemon_fetch.dart
@@ -1,0 +1,23 @@
+import 'package:pokemon_app/feature/base/model/pokemon.dart';
+import 'package:pokemon_app/feature/base/model/pokemon_detail.dart';
+import 'package:pokemon_app/service/api/api_client.dart';
+import 'package:pokemon_app/service/paging/model/paging.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'pokemon_fetch.g.dart';
+
+@riverpod
+Future<Paging<Pokemon>> fetchPokemonList(FetchPokemonListRef ref) {
+  return ref.watch(pokemonApiClientProvider).get<Paging<Pokemon>>(
+        path: 'pokemon',
+        decoder: (json) => Paging.fromJson(json, Pokemon.fromJson),
+      );
+}
+
+@riverpod
+Future<PokemonDetail> fetchPokemonDetail(FetchPokemonDetailRef ref, int id) {
+  return ref.watch(pokemonApiClientProvider).get<PokemonDetail>(
+        path: 'pokemon/$id',
+        decoder: PokemonDetail.fromJson,
+      );
+}

--- a/lib/feature/base/pokemon_fetch.g.dart
+++ b/lib/feature/base/pokemon_fetch.g.dart
@@ -1,0 +1,177 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pokemon_fetch.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$fetchPokemonListHash() => r'ab2f5bc9f2bed25f48f20755854a68bc66cfb32b';
+
+/// See also [fetchPokemonList].
+@ProviderFor(fetchPokemonList)
+final fetchPokemonListProvider =
+    AutoDisposeFutureProvider<Paging<Pokemon>>.internal(
+  fetchPokemonList,
+  name: r'fetchPokemonListProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$fetchPokemonListHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef FetchPokemonListRef = AutoDisposeFutureProviderRef<Paging<Pokemon>>;
+String _$fetchPokemonDetailHash() =>
+    r'fa66a3893ba371505c38a0d939e4b5ff958f6f52';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [fetchPokemonDetail].
+@ProviderFor(fetchPokemonDetail)
+const fetchPokemonDetailProvider = FetchPokemonDetailFamily();
+
+/// See also [fetchPokemonDetail].
+class FetchPokemonDetailFamily extends Family<AsyncValue<PokemonDetail>> {
+  /// See also [fetchPokemonDetail].
+  const FetchPokemonDetailFamily();
+
+  /// See also [fetchPokemonDetail].
+  FetchPokemonDetailProvider call(
+    int id,
+  ) {
+    return FetchPokemonDetailProvider(
+      id,
+    );
+  }
+
+  @override
+  FetchPokemonDetailProvider getProviderOverride(
+    covariant FetchPokemonDetailProvider provider,
+  ) {
+    return call(
+      provider.id,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'fetchPokemonDetailProvider';
+}
+
+/// See also [fetchPokemonDetail].
+class FetchPokemonDetailProvider
+    extends AutoDisposeFutureProvider<PokemonDetail> {
+  /// See also [fetchPokemonDetail].
+  FetchPokemonDetailProvider(
+    int id,
+  ) : this._internal(
+          (ref) => fetchPokemonDetail(
+            ref as FetchPokemonDetailRef,
+            id,
+          ),
+          from: fetchPokemonDetailProvider,
+          name: r'fetchPokemonDetailProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$fetchPokemonDetailHash,
+          dependencies: FetchPokemonDetailFamily._dependencies,
+          allTransitiveDependencies:
+              FetchPokemonDetailFamily._allTransitiveDependencies,
+          id: id,
+        );
+
+  FetchPokemonDetailProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.id,
+  }) : super.internal();
+
+  final int id;
+
+  @override
+  Override overrideWith(
+    FutureOr<PokemonDetail> Function(FetchPokemonDetailRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: FetchPokemonDetailProvider._internal(
+        (ref) => create(ref as FetchPokemonDetailRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        id: id,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<PokemonDetail> createElement() {
+    return _FetchPokemonDetailProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is FetchPokemonDetailProvider && other.id == id;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, id.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin FetchPokemonDetailRef on AutoDisposeFutureProviderRef<PokemonDetail> {
+  /// The parameter `id` of this provider.
+  int get id;
+}
+
+class _FetchPokemonDetailProviderElement
+    extends AutoDisposeFutureProviderElement<PokemonDetail>
+    with FetchPokemonDetailRef {
+  _FetchPokemonDetailProviderElement(super.provider);
+
+  @override
+  int get id => (origin as FetchPokemonDetailProvider).id;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/service/paging/model/paging.dart
+++ b/lib/service/paging/model/paging.dart
@@ -1,0 +1,22 @@
+class Paging<E> {
+  const Paging({
+    required this.totalCount,
+    required this.items,
+  });
+  final int totalCount;
+  final List<E> items;
+
+  // ignore: sort_constructors_first
+  factory Paging.fromJson(
+    Map<String, dynamic> json,
+    E Function(Map<String, dynamic> json) fromJsonE,
+  ) {
+    final items = json['results'] as List;
+    final itemsJson =
+        items.map((dynamic e) => e as Map<String, dynamic>).toList();
+    return Paging<E>(
+      totalCount: json['count'] as int,
+      items: itemsJson.map(fromJsonE).toList(),
+    );
+  }
+}


### PR DESCRIPTION
# 概要

- #14 の更新
-`PokemonDetail`Classを作成
- ポケモンの詳細データを取得する `fetchPokemonDetail`Providerを実装

# チェックリスト　

※ 実行したら x と記載し、当てはまらない場合は　 NA と記載する

- [x] Github 上でコードを確認して、コードが適切であることを確認した
- [x] Github 上でコードを確認して、不要な変更が含まれていないことを確認した
- [NA] 必要な箇所に `TODO`, `FIXME`を付けて、チケット ID を書いた
