### PR TITLE
一覧pageで表示するLlistItemを作成、pokemonDetailクラスのアップデート

### DIFF
--- a/lib/const/pokeapi_color.dart
+++ b/lib/const/pokeapi_color.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+const Map<String, Color> pokeTypeColors = {
+  'normal': Color(0xFFA8A77A),
+  'fire': Color(0xFFEE8130),
+  'water': Color(0xFF6390F0),
+  'electric': Color(0xFFF7D02C),
+  'grass': Color(0xFF7AC74C),
+  'ice': Color(0xFF96D9D6),
+  'fighting': Color(0xFFC22E28),
+  'poison': Color(0xFFA33EA1),
+  'ground': Color(0xFFE2BF65),
+  'flying': Color(0xFFA98FF3),
+  'psychic': Color(0xFFF95587),
+  'bug': Color(0xFFA6B91A),
+  'rock': Color(0xFFB6A136),
+  'ghost': Color(0xFF735797),
+  'dragon': Color(0xFF6F35FC),
+  'dark': Color(0xFF705746),
+  'steel': Color(0xFFB7B7CE),
+  'fairy': Color(0xFFD685AD),
+};

--- a/lib/feature/base/base_screen.dart
+++ b/lib/feature/base/base_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pokemon_app/feature/base/pokemon_fetch.dart';
+import 'package:pokemon_app/feature/base/widget/pokemon_list_item.dart';
 import 'package:pokemon_app/gen/assets.gen.dart';
 
 class BaseScreen extends ConsumerWidget {
@@ -49,9 +50,9 @@ class BaseScreen extends ConsumerWidget {
                       delegate: SliverChildBuilderDelegate(
                         childCount: data.items.length,
                         (context, index) {
-                          return Text(
-                            data.items[index].name,
-                          );
+                          final poke =
+                              ref.watch(fetchPokemonDetailProvider(index + 1));
+                          return PokemonListItem(poke: poke.value);
                         },
                       ),
                     ),

--- a/lib/feature/base/model/pokemon_detail.dart
+++ b/lib/feature/base/model/pokemon_detail.dart
@@ -7,11 +7,73 @@ part 'pokemon_detail.g.dart';
 class PokemonDetail with _$PokemonDetail {
   const factory PokemonDetail({
     required int id,
+    required String name,
     required int height,
     required int weight,
-    required List<Map<String, Object?>> stats,
+    required List<PokemonType> types,
+    required List<Stat> stats,
+    required Sprite sprites,
   }) = _PokemonDetail;
 
   factory PokemonDetail.fromJson(Map<String, dynamic> json) =>
       _$PokemonDetailFromJson(json);
+}
+
+@freezed
+class Stat with _$Stat {
+  const factory Stat({
+    @JsonKey(name: 'base_stat') required int baseStat,
+  }) = _Stat;
+
+  factory Stat.fromJson(Map<String, dynamic> json) => _$StatFromJson(json);
+}
+
+@freezed
+class PokemonType with _$PokemonType {
+  const factory PokemonType({
+    required int slot,
+    required TypeDetail type,
+  }) = _PokemonType;
+
+  factory PokemonType.fromJson(Map<String, dynamic> json) =>
+      _$PokemonTypeFromJson(json);
+}
+
+@freezed
+class TypeDetail with _$TypeDetail {
+  const factory TypeDetail({
+    required String name,
+    required String url,
+  }) = _TypeDetail;
+
+  factory TypeDetail.fromJson(Map<String, dynamic> json) =>
+      _$TypeDetailFromJson(json);
+}
+
+@freezed
+class Sprite with _$Sprite {
+  const factory Sprite({
+    required Other other,
+  }) = _Sprite;
+
+  factory Sprite.fromJson(Map<String, dynamic> json) => _$SpriteFromJson(json);
+}
+
+@freezed
+class Other with _$Other {
+  const factory Other({
+    @JsonKey(name: 'official-artwork') required OfficialArtwork officialArtwork,
+  }) = _Other;
+
+  factory Other.fromJson(Map<String, dynamic> json) => _$OtherFromJson(json);
+}
+
+@freezed
+class OfficialArtwork with _$OfficialArtwork {
+  const factory OfficialArtwork({
+    @JsonKey(name: 'front_default') required String frontDefault,
+  }) = _OfficialArtwork;
+
+  factory OfficialArtwork.fromJson(Map<String, dynamic> json) =>
+      _$OfficialArtworkFromJson(json);
 }

--- a/lib/feature/base/model/pokemon_detail.freezed.dart
+++ b/lib/feature/base/model/pokemon_detail.freezed.dart
@@ -21,9 +21,12 @@ PokemonDetail _$PokemonDetailFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$PokemonDetail {
   int get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
   int get height => throw _privateConstructorUsedError;
   int get weight => throw _privateConstructorUsedError;
-  List<Map<String, Object?>> get stats => throw _privateConstructorUsedError;
+  List<PokemonType> get types => throw _privateConstructorUsedError;
+  List<Stat> get stats => throw _privateConstructorUsedError;
+  Sprite get sprites => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -37,7 +40,16 @@ abstract class $PokemonDetailCopyWith<$Res> {
           PokemonDetail value, $Res Function(PokemonDetail) then) =
       _$PokemonDetailCopyWithImpl<$Res, PokemonDetail>;
   @useResult
-  $Res call({int id, int height, int weight, List<Map<String, Object?>> stats});
+  $Res call(
+      {int id,
+      String name,
+      int height,
+      int weight,
+      List<PokemonType> types,
+      List<Stat> stats,
+      Sprite sprites});
+
+  $SpriteCopyWith<$Res> get sprites;
 }
 
 /// @nodoc
@@ -54,15 +66,22 @@ class _$PokemonDetailCopyWithImpl<$Res, $Val extends PokemonDetail>
   @override
   $Res call({
     Object? id = null,
+    Object? name = null,
     Object? height = null,
     Object? weight = null,
+    Object? types = null,
     Object? stats = null,
+    Object? sprites = null,
   }) {
     return _then(_value.copyWith(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
       height: null == height
           ? _value.height
           : height // ignore: cast_nullable_to_non_nullable
@@ -71,11 +90,27 @@ class _$PokemonDetailCopyWithImpl<$Res, $Val extends PokemonDetail>
           ? _value.weight
           : weight // ignore: cast_nullable_to_non_nullable
               as int,
+      types: null == types
+          ? _value.types
+          : types // ignore: cast_nullable_to_non_nullable
+              as List<PokemonType>,
       stats: null == stats
           ? _value.stats
           : stats // ignore: cast_nullable_to_non_nullable
-              as List<Map<String, Object?>>,
+              as List<Stat>,
+      sprites: null == sprites
+          ? _value.sprites
+          : sprites // ignore: cast_nullable_to_non_nullable
+              as Sprite,
     ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SpriteCopyWith<$Res> get sprites {
+    return $SpriteCopyWith<$Res>(_value.sprites, (value) {
+      return _then(_value.copyWith(sprites: value) as $Val);
+    });
   }
 }
 
@@ -87,7 +122,17 @@ abstract class _$$PokemonDetailImplCopyWith<$Res>
       __$$PokemonDetailImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int id, int height, int weight, List<Map<String, Object?>> stats});
+  $Res call(
+      {int id,
+      String name,
+      int height,
+      int weight,
+      List<PokemonType> types,
+      List<Stat> stats,
+      Sprite sprites});
+
+  @override
+  $SpriteCopyWith<$Res> get sprites;
 }
 
 /// @nodoc
@@ -102,15 +147,22 @@ class __$$PokemonDetailImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? id = null,
+    Object? name = null,
     Object? height = null,
     Object? weight = null,
+    Object? types = null,
     Object? stats = null,
+    Object? sprites = null,
   }) {
     return _then(_$PokemonDetailImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
       height: null == height
           ? _value.height
           : height // ignore: cast_nullable_to_non_nullable
@@ -119,10 +171,18 @@ class __$$PokemonDetailImplCopyWithImpl<$Res>
           ? _value.weight
           : weight // ignore: cast_nullable_to_non_nullable
               as int,
+      types: null == types
+          ? _value._types
+          : types // ignore: cast_nullable_to_non_nullable
+              as List<PokemonType>,
       stats: null == stats
           ? _value._stats
           : stats // ignore: cast_nullable_to_non_nullable
-              as List<Map<String, Object?>>,
+              as List<Stat>,
+      sprites: null == sprites
+          ? _value.sprites
+          : sprites // ignore: cast_nullable_to_non_nullable
+              as Sprite,
     ));
   }
 }
@@ -132,10 +192,14 @@ class __$$PokemonDetailImplCopyWithImpl<$Res>
 class _$PokemonDetailImpl implements _PokemonDetail {
   const _$PokemonDetailImpl(
       {required this.id,
+      required this.name,
       required this.height,
       required this.weight,
-      required final List<Map<String, Object?>> stats})
-      : _stats = stats;
+      required final List<PokemonType> types,
+      required final List<Stat> stats,
+      required this.sprites})
+      : _types = types,
+        _stats = stats;
 
   factory _$PokemonDetailImpl.fromJson(Map<String, dynamic> json) =>
       _$$PokemonDetailImplFromJson(json);
@@ -143,20 +207,33 @@ class _$PokemonDetailImpl implements _PokemonDetail {
   @override
   final int id;
   @override
+  final String name;
+  @override
   final int height;
   @override
   final int weight;
-  final List<Map<String, Object?>> _stats;
+  final List<PokemonType> _types;
   @override
-  List<Map<String, Object?>> get stats {
+  List<PokemonType> get types {
+    if (_types is EqualUnmodifiableListView) return _types;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_types);
+  }
+
+  final List<Stat> _stats;
+  @override
+  List<Stat> get stats {
     if (_stats is EqualUnmodifiableListView) return _stats;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_stats);
   }
 
   @override
+  final Sprite sprites;
+
+  @override
   String toString() {
-    return 'PokemonDetail(id: $id, height: $height, weight: $weight, stats: $stats)';
+    return 'PokemonDetail(id: $id, name: $name, height: $height, weight: $weight, types: $types, stats: $stats, sprites: $sprites)';
   }
 
   @override
@@ -165,15 +242,25 @@ class _$PokemonDetailImpl implements _PokemonDetail {
         (other.runtimeType == runtimeType &&
             other is _$PokemonDetailImpl &&
             (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
             (identical(other.height, height) || other.height == height) &&
             (identical(other.weight, weight) || other.weight == weight) &&
-            const DeepCollectionEquality().equals(other._stats, _stats));
+            const DeepCollectionEquality().equals(other._types, _types) &&
+            const DeepCollectionEquality().equals(other._stats, _stats) &&
+            (identical(other.sprites, sprites) || other.sprites == sprites));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, id, height, weight,
-      const DeepCollectionEquality().hash(_stats));
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      name,
+      height,
+      weight,
+      const DeepCollectionEquality().hash(_types),
+      const DeepCollectionEquality().hash(_stats),
+      sprites);
 
   @JsonKey(ignore: true)
   @override
@@ -192,9 +279,12 @@ class _$PokemonDetailImpl implements _PokemonDetail {
 abstract class _PokemonDetail implements PokemonDetail {
   const factory _PokemonDetail(
       {required final int id,
+      required final String name,
       required final int height,
       required final int weight,
-      required final List<Map<String, Object?>> stats}) = _$PokemonDetailImpl;
+      required final List<PokemonType> types,
+      required final List<Stat> stats,
+      required final Sprite sprites}) = _$PokemonDetailImpl;
 
   factory _PokemonDetail.fromJson(Map<String, dynamic> json) =
       _$PokemonDetailImpl.fromJson;
@@ -202,13 +292,919 @@ abstract class _PokemonDetail implements PokemonDetail {
   @override
   int get id;
   @override
+  String get name;
+  @override
   int get height;
   @override
   int get weight;
   @override
-  List<Map<String, Object?>> get stats;
+  List<PokemonType> get types;
+  @override
+  List<Stat> get stats;
+  @override
+  Sprite get sprites;
   @override
   @JsonKey(ignore: true)
   _$$PokemonDetailImplCopyWith<_$PokemonDetailImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+Stat _$StatFromJson(Map<String, dynamic> json) {
+  return _Stat.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Stat {
+  @JsonKey(name: 'base_stat')
+  int get baseStat => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $StatCopyWith<Stat> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StatCopyWith<$Res> {
+  factory $StatCopyWith(Stat value, $Res Function(Stat) then) =
+      _$StatCopyWithImpl<$Res, Stat>;
+  @useResult
+  $Res call({@JsonKey(name: 'base_stat') int baseStat});
+}
+
+/// @nodoc
+class _$StatCopyWithImpl<$Res, $Val extends Stat>
+    implements $StatCopyWith<$Res> {
+  _$StatCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? baseStat = null,
+  }) {
+    return _then(_value.copyWith(
+      baseStat: null == baseStat
+          ? _value.baseStat
+          : baseStat // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$StatImplCopyWith<$Res> implements $StatCopyWith<$Res> {
+  factory _$$StatImplCopyWith(
+          _$StatImpl value, $Res Function(_$StatImpl) then) =
+      __$$StatImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'base_stat') int baseStat});
+}
+
+/// @nodoc
+class __$$StatImplCopyWithImpl<$Res>
+    extends _$StatCopyWithImpl<$Res, _$StatImpl>
+    implements _$$StatImplCopyWith<$Res> {
+  __$$StatImplCopyWithImpl(_$StatImpl _value, $Res Function(_$StatImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? baseStat = null,
+  }) {
+    return _then(_$StatImpl(
+      baseStat: null == baseStat
+          ? _value.baseStat
+          : baseStat // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$StatImpl implements _Stat {
+  const _$StatImpl({@JsonKey(name: 'base_stat') required this.baseStat});
+
+  factory _$StatImpl.fromJson(Map<String, dynamic> json) =>
+      _$$StatImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'base_stat')
+  final int baseStat;
+
+  @override
+  String toString() {
+    return 'Stat(baseStat: $baseStat)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$StatImpl &&
+            (identical(other.baseStat, baseStat) ||
+                other.baseStat == baseStat));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, baseStat);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$StatImplCopyWith<_$StatImpl> get copyWith =>
+      __$$StatImplCopyWithImpl<_$StatImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$StatImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Stat implements Stat {
+  const factory _Stat(
+      {@JsonKey(name: 'base_stat') required final int baseStat}) = _$StatImpl;
+
+  factory _Stat.fromJson(Map<String, dynamic> json) = _$StatImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'base_stat')
+  int get baseStat;
+  @override
+  @JsonKey(ignore: true)
+  _$$StatImplCopyWith<_$StatImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+PokemonType _$PokemonTypeFromJson(Map<String, dynamic> json) {
+  return _PokemonType.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PokemonType {
+  int get slot => throw _privateConstructorUsedError;
+  TypeDetail get type => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PokemonTypeCopyWith<PokemonType> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PokemonTypeCopyWith<$Res> {
+  factory $PokemonTypeCopyWith(
+          PokemonType value, $Res Function(PokemonType) then) =
+      _$PokemonTypeCopyWithImpl<$Res, PokemonType>;
+  @useResult
+  $Res call({int slot, TypeDetail type});
+
+  $TypeDetailCopyWith<$Res> get type;
+}
+
+/// @nodoc
+class _$PokemonTypeCopyWithImpl<$Res, $Val extends PokemonType>
+    implements $PokemonTypeCopyWith<$Res> {
+  _$PokemonTypeCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? slot = null,
+    Object? type = null,
+  }) {
+    return _then(_value.copyWith(
+      slot: null == slot
+          ? _value.slot
+          : slot // ignore: cast_nullable_to_non_nullable
+              as int,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as TypeDetail,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $TypeDetailCopyWith<$Res> get type {
+    return $TypeDetailCopyWith<$Res>(_value.type, (value) {
+      return _then(_value.copyWith(type: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$PokemonTypeImplCopyWith<$Res>
+    implements $PokemonTypeCopyWith<$Res> {
+  factory _$$PokemonTypeImplCopyWith(
+          _$PokemonTypeImpl value, $Res Function(_$PokemonTypeImpl) then) =
+      __$$PokemonTypeImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int slot, TypeDetail type});
+
+  @override
+  $TypeDetailCopyWith<$Res> get type;
+}
+
+/// @nodoc
+class __$$PokemonTypeImplCopyWithImpl<$Res>
+    extends _$PokemonTypeCopyWithImpl<$Res, _$PokemonTypeImpl>
+    implements _$$PokemonTypeImplCopyWith<$Res> {
+  __$$PokemonTypeImplCopyWithImpl(
+      _$PokemonTypeImpl _value, $Res Function(_$PokemonTypeImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? slot = null,
+    Object? type = null,
+  }) {
+    return _then(_$PokemonTypeImpl(
+      slot: null == slot
+          ? _value.slot
+          : slot // ignore: cast_nullable_to_non_nullable
+              as int,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as TypeDetail,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PokemonTypeImpl implements _PokemonType {
+  const _$PokemonTypeImpl({required this.slot, required this.type});
+
+  factory _$PokemonTypeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PokemonTypeImplFromJson(json);
+
+  @override
+  final int slot;
+  @override
+  final TypeDetail type;
+
+  @override
+  String toString() {
+    return 'PokemonType(slot: $slot, type: $type)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PokemonTypeImpl &&
+            (identical(other.slot, slot) || other.slot == slot) &&
+            (identical(other.type, type) || other.type == type));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, slot, type);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PokemonTypeImplCopyWith<_$PokemonTypeImpl> get copyWith =>
+      __$$PokemonTypeImplCopyWithImpl<_$PokemonTypeImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PokemonTypeImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PokemonType implements PokemonType {
+  const factory _PokemonType(
+      {required final int slot,
+      required final TypeDetail type}) = _$PokemonTypeImpl;
+
+  factory _PokemonType.fromJson(Map<String, dynamic> json) =
+      _$PokemonTypeImpl.fromJson;
+
+  @override
+  int get slot;
+  @override
+  TypeDetail get type;
+  @override
+  @JsonKey(ignore: true)
+  _$$PokemonTypeImplCopyWith<_$PokemonTypeImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+TypeDetail _$TypeDetailFromJson(Map<String, dynamic> json) {
+  return _TypeDetail.fromJson(json);
+}
+
+/// @nodoc
+mixin _$TypeDetail {
+  String get name => throw _privateConstructorUsedError;
+  String get url => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $TypeDetailCopyWith<TypeDetail> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TypeDetailCopyWith<$Res> {
+  factory $TypeDetailCopyWith(
+          TypeDetail value, $Res Function(TypeDetail) then) =
+      _$TypeDetailCopyWithImpl<$Res, TypeDetail>;
+  @useResult
+  $Res call({String name, String url});
+}
+
+/// @nodoc
+class _$TypeDetailCopyWithImpl<$Res, $Val extends TypeDetail>
+    implements $TypeDetailCopyWith<$Res> {
+  _$TypeDetailCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? url = null,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$TypeDetailImplCopyWith<$Res>
+    implements $TypeDetailCopyWith<$Res> {
+  factory _$$TypeDetailImplCopyWith(
+          _$TypeDetailImpl value, $Res Function(_$TypeDetailImpl) then) =
+      __$$TypeDetailImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String name, String url});
+}
+
+/// @nodoc
+class __$$TypeDetailImplCopyWithImpl<$Res>
+    extends _$TypeDetailCopyWithImpl<$Res, _$TypeDetailImpl>
+    implements _$$TypeDetailImplCopyWith<$Res> {
+  __$$TypeDetailImplCopyWithImpl(
+      _$TypeDetailImpl _value, $Res Function(_$TypeDetailImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? url = null,
+  }) {
+    return _then(_$TypeDetailImpl(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$TypeDetailImpl implements _TypeDetail {
+  const _$TypeDetailImpl({required this.name, required this.url});
+
+  factory _$TypeDetailImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TypeDetailImplFromJson(json);
+
+  @override
+  final String name;
+  @override
+  final String url;
+
+  @override
+  String toString() {
+    return 'TypeDetail(name: $name, url: $url)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TypeDetailImpl &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.url, url) || other.url == url));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, name, url);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TypeDetailImplCopyWith<_$TypeDetailImpl> get copyWith =>
+      __$$TypeDetailImplCopyWithImpl<_$TypeDetailImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TypeDetailImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _TypeDetail implements TypeDetail {
+  const factory _TypeDetail(
+      {required final String name,
+      required final String url}) = _$TypeDetailImpl;
+
+  factory _TypeDetail.fromJson(Map<String, dynamic> json) =
+      _$TypeDetailImpl.fromJson;
+
+  @override
+  String get name;
+  @override
+  String get url;
+  @override
+  @JsonKey(ignore: true)
+  _$$TypeDetailImplCopyWith<_$TypeDetailImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+Sprite _$SpriteFromJson(Map<String, dynamic> json) {
+  return _Sprite.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Sprite {
+  Other get other => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SpriteCopyWith<Sprite> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SpriteCopyWith<$Res> {
+  factory $SpriteCopyWith(Sprite value, $Res Function(Sprite) then) =
+      _$SpriteCopyWithImpl<$Res, Sprite>;
+  @useResult
+  $Res call({Other other});
+
+  $OtherCopyWith<$Res> get other;
+}
+
+/// @nodoc
+class _$SpriteCopyWithImpl<$Res, $Val extends Sprite>
+    implements $SpriteCopyWith<$Res> {
+  _$SpriteCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? other = null,
+  }) {
+    return _then(_value.copyWith(
+      other: null == other
+          ? _value.other
+          : other // ignore: cast_nullable_to_non_nullable
+              as Other,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OtherCopyWith<$Res> get other {
+    return $OtherCopyWith<$Res>(_value.other, (value) {
+      return _then(_value.copyWith(other: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$SpriteImplCopyWith<$Res> implements $SpriteCopyWith<$Res> {
+  factory _$$SpriteImplCopyWith(
+          _$SpriteImpl value, $Res Function(_$SpriteImpl) then) =
+      __$$SpriteImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Other other});
+
+  @override
+  $OtherCopyWith<$Res> get other;
+}
+
+/// @nodoc
+class __$$SpriteImplCopyWithImpl<$Res>
+    extends _$SpriteCopyWithImpl<$Res, _$SpriteImpl>
+    implements _$$SpriteImplCopyWith<$Res> {
+  __$$SpriteImplCopyWithImpl(
+      _$SpriteImpl _value, $Res Function(_$SpriteImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? other = null,
+  }) {
+    return _then(_$SpriteImpl(
+      other: null == other
+          ? _value.other
+          : other // ignore: cast_nullable_to_non_nullable
+              as Other,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SpriteImpl implements _Sprite {
+  const _$SpriteImpl({required this.other});
+
+  factory _$SpriteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SpriteImplFromJson(json);
+
+  @override
+  final Other other;
+
+  @override
+  String toString() {
+    return 'Sprite(other: $other)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SpriteImpl &&
+            (identical(other.other, this.other) || other.other == this.other));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, other);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SpriteImplCopyWith<_$SpriteImpl> get copyWith =>
+      __$$SpriteImplCopyWithImpl<_$SpriteImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SpriteImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Sprite implements Sprite {
+  const factory _Sprite({required final Other other}) = _$SpriteImpl;
+
+  factory _Sprite.fromJson(Map<String, dynamic> json) = _$SpriteImpl.fromJson;
+
+  @override
+  Other get other;
+  @override
+  @JsonKey(ignore: true)
+  _$$SpriteImplCopyWith<_$SpriteImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+Other _$OtherFromJson(Map<String, dynamic> json) {
+  return _Other.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Other {
+  @JsonKey(name: 'official-artwork')
+  OfficialArtwork get officialArtwork => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $OtherCopyWith<Other> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $OtherCopyWith<$Res> {
+  factory $OtherCopyWith(Other value, $Res Function(Other) then) =
+      _$OtherCopyWithImpl<$Res, Other>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'official-artwork') OfficialArtwork officialArtwork});
+
+  $OfficialArtworkCopyWith<$Res> get officialArtwork;
+}
+
+/// @nodoc
+class _$OtherCopyWithImpl<$Res, $Val extends Other>
+    implements $OtherCopyWith<$Res> {
+  _$OtherCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? officialArtwork = null,
+  }) {
+    return _then(_value.copyWith(
+      officialArtwork: null == officialArtwork
+          ? _value.officialArtwork
+          : officialArtwork // ignore: cast_nullable_to_non_nullable
+              as OfficialArtwork,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OfficialArtworkCopyWith<$Res> get officialArtwork {
+    return $OfficialArtworkCopyWith<$Res>(_value.officialArtwork, (value) {
+      return _then(_value.copyWith(officialArtwork: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$OtherImplCopyWith<$Res> implements $OtherCopyWith<$Res> {
+  factory _$$OtherImplCopyWith(
+          _$OtherImpl value, $Res Function(_$OtherImpl) then) =
+      __$$OtherImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'official-artwork') OfficialArtwork officialArtwork});
+
+  @override
+  $OfficialArtworkCopyWith<$Res> get officialArtwork;
+}
+
+/// @nodoc
+class __$$OtherImplCopyWithImpl<$Res>
+    extends _$OtherCopyWithImpl<$Res, _$OtherImpl>
+    implements _$$OtherImplCopyWith<$Res> {
+  __$$OtherImplCopyWithImpl(
+      _$OtherImpl _value, $Res Function(_$OtherImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? officialArtwork = null,
+  }) {
+    return _then(_$OtherImpl(
+      officialArtwork: null == officialArtwork
+          ? _value.officialArtwork
+          : officialArtwork // ignore: cast_nullable_to_non_nullable
+              as OfficialArtwork,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$OtherImpl implements _Other {
+  const _$OtherImpl(
+      {@JsonKey(name: 'official-artwork') required this.officialArtwork});
+
+  factory _$OtherImpl.fromJson(Map<String, dynamic> json) =>
+      _$$OtherImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'official-artwork')
+  final OfficialArtwork officialArtwork;
+
+  @override
+  String toString() {
+    return 'Other(officialArtwork: $officialArtwork)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OtherImpl &&
+            (identical(other.officialArtwork, officialArtwork) ||
+                other.officialArtwork == officialArtwork));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, officialArtwork);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OtherImplCopyWith<_$OtherImpl> get copyWith =>
+      __$$OtherImplCopyWithImpl<_$OtherImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$OtherImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Other implements Other {
+  const factory _Other(
+      {@JsonKey(name: 'official-artwork')
+      required final OfficialArtwork officialArtwork}) = _$OtherImpl;
+
+  factory _Other.fromJson(Map<String, dynamic> json) = _$OtherImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'official-artwork')
+  OfficialArtwork get officialArtwork;
+  @override
+  @JsonKey(ignore: true)
+  _$$OtherImplCopyWith<_$OtherImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+OfficialArtwork _$OfficialArtworkFromJson(Map<String, dynamic> json) {
+  return _OfficialArtwork.fromJson(json);
+}
+
+/// @nodoc
+mixin _$OfficialArtwork {
+  @JsonKey(name: 'front_default')
+  String get frontDefault => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $OfficialArtworkCopyWith<OfficialArtwork> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $OfficialArtworkCopyWith<$Res> {
+  factory $OfficialArtworkCopyWith(
+          OfficialArtwork value, $Res Function(OfficialArtwork) then) =
+      _$OfficialArtworkCopyWithImpl<$Res, OfficialArtwork>;
+  @useResult
+  $Res call({@JsonKey(name: 'front_default') String frontDefault});
+}
+
+/// @nodoc
+class _$OfficialArtworkCopyWithImpl<$Res, $Val extends OfficialArtwork>
+    implements $OfficialArtworkCopyWith<$Res> {
+  _$OfficialArtworkCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? frontDefault = null,
+  }) {
+    return _then(_value.copyWith(
+      frontDefault: null == frontDefault
+          ? _value.frontDefault
+          : frontDefault // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$OfficialArtworkImplCopyWith<$Res>
+    implements $OfficialArtworkCopyWith<$Res> {
+  factory _$$OfficialArtworkImplCopyWith(_$OfficialArtworkImpl value,
+          $Res Function(_$OfficialArtworkImpl) then) =
+      __$$OfficialArtworkImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'front_default') String frontDefault});
+}
+
+/// @nodoc
+class __$$OfficialArtworkImplCopyWithImpl<$Res>
+    extends _$OfficialArtworkCopyWithImpl<$Res, _$OfficialArtworkImpl>
+    implements _$$OfficialArtworkImplCopyWith<$Res> {
+  __$$OfficialArtworkImplCopyWithImpl(
+      _$OfficialArtworkImpl _value, $Res Function(_$OfficialArtworkImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? frontDefault = null,
+  }) {
+    return _then(_$OfficialArtworkImpl(
+      frontDefault: null == frontDefault
+          ? _value.frontDefault
+          : frontDefault // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$OfficialArtworkImpl implements _OfficialArtwork {
+  const _$OfficialArtworkImpl(
+      {@JsonKey(name: 'front_default') required this.frontDefault});
+
+  factory _$OfficialArtworkImpl.fromJson(Map<String, dynamic> json) =>
+      _$$OfficialArtworkImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'front_default')
+  final String frontDefault;
+
+  @override
+  String toString() {
+    return 'OfficialArtwork(frontDefault: $frontDefault)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OfficialArtworkImpl &&
+            (identical(other.frontDefault, frontDefault) ||
+                other.frontDefault == frontDefault));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, frontDefault);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OfficialArtworkImplCopyWith<_$OfficialArtworkImpl> get copyWith =>
+      __$$OfficialArtworkImplCopyWithImpl<_$OfficialArtworkImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$OfficialArtworkImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _OfficialArtwork implements OfficialArtwork {
+  const factory _OfficialArtwork(
+      {@JsonKey(name: 'front_default')
+      required final String frontDefault}) = _$OfficialArtworkImpl;
+
+  factory _OfficialArtwork.fromJson(Map<String, dynamic> json) =
+      _$OfficialArtworkImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'front_default')
+  String get frontDefault;
+  @override
+  @JsonKey(ignore: true)
+  _$$OfficialArtworkImplCopyWith<_$OfficialArtworkImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/feature/base/model/pokemon_detail.g.dart
+++ b/lib/feature/base/model/pokemon_detail.g.dart
@@ -9,17 +9,89 @@ part of 'pokemon_detail.dart';
 _$PokemonDetailImpl _$$PokemonDetailImplFromJson(Map<String, dynamic> json) =>
     _$PokemonDetailImpl(
       id: json['id'] as int,
+      name: json['name'] as String,
       height: json['height'] as int,
       weight: json['weight'] as int,
-      stats: (json['stats'] as List<dynamic>)
-          .map((e) => e as Map<String, dynamic>)
+      types: (json['types'] as List<dynamic>)
+          .map((e) => PokemonType.fromJson(e as Map<String, dynamic>))
           .toList(),
+      stats: (json['stats'] as List<dynamic>)
+          .map((e) => Stat.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      sprites: Sprite.fromJson(json['sprites'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$$PokemonDetailImplToJson(_$PokemonDetailImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
+      'name': instance.name,
       'height': instance.height,
       'weight': instance.weight,
+      'types': instance.types,
       'stats': instance.stats,
+      'sprites': instance.sprites,
+    };
+
+_$StatImpl _$$StatImplFromJson(Map<String, dynamic> json) => _$StatImpl(
+      baseStat: json['base_stat'] as int,
+    );
+
+Map<String, dynamic> _$$StatImplToJson(_$StatImpl instance) =>
+    <String, dynamic>{
+      'base_stat': instance.baseStat,
+    };
+
+_$PokemonTypeImpl _$$PokemonTypeImplFromJson(Map<String, dynamic> json) =>
+    _$PokemonTypeImpl(
+      slot: json['slot'] as int,
+      type: TypeDetail.fromJson(json['type'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$PokemonTypeImplToJson(_$PokemonTypeImpl instance) =>
+    <String, dynamic>{
+      'slot': instance.slot,
+      'type': instance.type,
+    };
+
+_$TypeDetailImpl _$$TypeDetailImplFromJson(Map<String, dynamic> json) =>
+    _$TypeDetailImpl(
+      name: json['name'] as String,
+      url: json['url'] as String,
+    );
+
+Map<String, dynamic> _$$TypeDetailImplToJson(_$TypeDetailImpl instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'url': instance.url,
+    };
+
+_$SpriteImpl _$$SpriteImplFromJson(Map<String, dynamic> json) => _$SpriteImpl(
+      other: Other.fromJson(json['other'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$SpriteImplToJson(_$SpriteImpl instance) =>
+    <String, dynamic>{
+      'other': instance.other,
+    };
+
+_$OtherImpl _$$OtherImplFromJson(Map<String, dynamic> json) => _$OtherImpl(
+      officialArtwork: OfficialArtwork.fromJson(
+          json['official-artwork'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$OtherImplToJson(_$OtherImpl instance) =>
+    <String, dynamic>{
+      'official-artwork': instance.officialArtwork,
+    };
+
+_$OfficialArtworkImpl _$$OfficialArtworkImplFromJson(
+        Map<String, dynamic> json) =>
+    _$OfficialArtworkImpl(
+      frontDefault: json['front_default'] as String,
+    );
+
+Map<String, dynamic> _$$OfficialArtworkImplToJson(
+        _$OfficialArtworkImpl instance) =>
+    <String, dynamic>{
+      'front_default': instance.frontDefault,
     };

--- a/lib/feature/base/pokemon_fetch.dart
+++ b/lib/feature/base/pokemon_fetch.dart
@@ -6,15 +6,16 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'pokemon_fetch.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 Future<Paging<Pokemon>> fetchPokemonList(FetchPokemonListRef ref) {
   return ref.watch(pokemonApiClientProvider).get<Paging<Pokemon>>(
         path: 'pokemon',
+        queryParams: {'limit': '100'},
         decoder: (json) => Paging.fromJson(json, Pokemon.fromJson),
       );
 }
 
-@riverpod
+@Riverpod(keepAlive: true)
 Future<PokemonDetail> fetchPokemonDetail(FetchPokemonDetailRef ref, int id) {
   return ref.watch(pokemonApiClientProvider).get<PokemonDetail>(
         path: 'pokemon/$id',

--- a/lib/feature/base/pokemon_fetch.g.dart
+++ b/lib/feature/base/pokemon_fetch.g.dart
@@ -6,12 +6,11 @@ part of 'pokemon_fetch.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$fetchPokemonListHash() => r'ab2f5bc9f2bed25f48f20755854a68bc66cfb32b';
+String _$fetchPokemonListHash() => r'33a5f673cf602a00cc4c5846a6b1a7cc1268b892';
 
 /// See also [fetchPokemonList].
 @ProviderFor(fetchPokemonList)
-final fetchPokemonListProvider =
-    AutoDisposeFutureProvider<Paging<Pokemon>>.internal(
+final fetchPokemonListProvider = FutureProvider<Paging<Pokemon>>.internal(
   fetchPokemonList,
   name: r'fetchPokemonListProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -21,9 +20,9 @@ final fetchPokemonListProvider =
   allTransitiveDependencies: null,
 );
 
-typedef FetchPokemonListRef = AutoDisposeFutureProviderRef<Paging<Pokemon>>;
+typedef FetchPokemonListRef = FutureProviderRef<Paging<Pokemon>>;
 String _$fetchPokemonDetailHash() =>
-    r'fa66a3893ba371505c38a0d939e4b5ff958f6f52';
+    r'de044c7312a6eadac542e713dec4fe46493e9ad6';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -89,8 +88,7 @@ class FetchPokemonDetailFamily extends Family<AsyncValue<PokemonDetail>> {
 }
 
 /// See also [fetchPokemonDetail].
-class FetchPokemonDetailProvider
-    extends AutoDisposeFutureProvider<PokemonDetail> {
+class FetchPokemonDetailProvider extends FutureProvider<PokemonDetail> {
   /// See also [fetchPokemonDetail].
   FetchPokemonDetailProvider(
     int id,
@@ -142,7 +140,7 @@ class FetchPokemonDetailProvider
   }
 
   @override
-  AutoDisposeFutureProviderElement<PokemonDetail> createElement() {
+  FutureProviderElement<PokemonDetail> createElement() {
     return _FetchPokemonDetailProviderElement(this);
   }
 
@@ -160,14 +158,13 @@ class FetchPokemonDetailProvider
   }
 }
 
-mixin FetchPokemonDetailRef on AutoDisposeFutureProviderRef<PokemonDetail> {
+mixin FetchPokemonDetailRef on FutureProviderRef<PokemonDetail> {
   /// The parameter `id` of this provider.
   int get id;
 }
 
 class _FetchPokemonDetailProviderElement
-    extends AutoDisposeFutureProviderElement<PokemonDetail>
-    with FetchPokemonDetailRef {
+    extends FutureProviderElement<PokemonDetail> with FetchPokemonDetailRef {
   _FetchPokemonDetailProviderElement(super.provider);
 
   @override

--- a/lib/feature/base/widget/pokemon_list_item.dart
+++ b/lib/feature/base/widget/pokemon_list_item.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pokemon_app/const/pokeapi_color.dart';
+import 'package:pokemon_app/feature/base/model/pokemon_detail.dart';
+
+class PokemonListItem extends ConsumerWidget {
+  const PokemonListItem({super.key, required this.poke});
+  final PokemonDetail? poke;
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (poke != null) {
+      return ListTile(
+        leading: Container(
+          width: 80,
+          decoration: BoxDecoration(
+            color: (pokeTypeColors[poke!.types.first.type.name] ??
+                    Colors.grey[100])
+                ?.withOpacity(.3),
+            borderRadius: BorderRadius.circular(10),
+            image: DecorationImage(
+              fit: BoxFit.fitWidth,
+              image: NetworkImage(
+                poke!.sprites.other.officialArtwork.frontDefault,
+              ),
+            ),
+          ),
+        ),
+        title: Text(
+          poke!.name,
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+        subtitle: Text(poke!.types.first.type.name),
+        trailing: const Icon(Icons.navigate_next),
+        onTap: () => {
+          // Navigator.of(context).push(
+          //   MaterialPageRoute(
+          //     builder: (BuildContext context) => const PokeDetail(),
+          //   ),
+          // ),
+        },
+      );
+    } else {
+      return const ListTile(title: Text('...'));
+    }
+  }
+}

--- a/lib/service/api/api_client.dart
+++ b/lib/service/api/api_client.dart
@@ -4,7 +4,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'api_client.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 ApiClient pokemonApiClient(PokemonApiClientRef ref) {
   return ApiClient();
 }
@@ -19,6 +19,7 @@ class ApiClient {
 
   Future<T> get<T>({
     required String path,
+    Map<String, dynamic>? queryParams,
     required T Function(Map<String, dynamic> json) decoder,
   }) async {
     final res = await http
@@ -26,6 +27,7 @@ class ApiClient {
           Uri.https(
             _host,
             'api/v2/$path',
+            queryParams,
           ),
           headers: _headers,
         )

--- a/lib/service/api/api_client.g.dart
+++ b/lib/service/api/api_client.g.dart
@@ -6,11 +6,11 @@ part of 'api_client.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$pokemonApiClientHash() => r'84ff7ebc486196db3858fbc3fd0698fba825432d';
+String _$pokemonApiClientHash() => r'536c4c6f38dad3afa54e36738d84949346cc7be1';
 
 /// See also [pokemonApiClient].
 @ProviderFor(pokemonApiClient)
-final pokemonApiClientProvider = AutoDisposeProvider<ApiClient>.internal(
+final pokemonApiClientProvider = Provider<ApiClient>.internal(
   pokemonApiClient,
   name: r'pokemonApiClientProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -20,6 +20,6 @@ final pokemonApiClientProvider = AutoDisposeProvider<ApiClient>.internal(
   allTransitiveDependencies: null,
 );
 
-typedef PokemonApiClientRef = AutoDisposeProviderRef<ApiClient>;
+typedef PokemonApiClientRef = ProviderRef<ApiClient>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member


### PR DESCRIPTION
# 概要

- 一覧pageで表示するListItemを作成
- `pokemonDetail`のプロパティ追加
- providerをkeepAliveに変更

# スクリーンショット (UI の追加、変更時に添付)

![Screenshot 2024-03-16 at 23 12 10](https://github.com/yyupyong/pokemon-app/assets/109585930/d0863a8f-3d5f-4fb6-b8a5-12addc12c19f)

※ 実行したら x と記載し、当てはまらない場合は　 NA と記載する

- [x] Github 上でコードを確認して、コードが適切であることを確認した
- [x] Github 上でコードを確認して、不要な変更が含まれていないことを確認した
- [NA] 必要な箇所に `TODO`, `FIXME`を付けて、チケット ID を書いた
