### PR TITLE
詳細画面へ遷移時アニメーションを追加

### DIFF
--- a/lib/feature/detail/pokemon_detail_screen.dart
+++ b/lib/feature/detail/pokemon_detail_screen.dart
@@ -87,10 +87,13 @@ class PokemonDetailScreen extends StatelessWidget {
             padding: const EdgeInsets.only(top: 200),
             child: Column(
               children: [
-                Image.network(
-                  poke.sprites.other.officialArtwork.frontDefault,
-                  height: 260,
-                  width: 260,
+                Hero(
+                  tag: 'pokemon_${poke.id}',
+                  child: Image.network(
+                    poke.sprites.other.officialArtwork.frontDefault,
+                    height: 260,
+                    width: 260,
+                  ),
                 ),
                 const SizedBox(height: 12),
                 Row(

--- a/lib/feature/home/widget/pokemon_list_item.dart
+++ b/lib/feature/home/widget/pokemon_list_item.dart
@@ -17,17 +17,20 @@ class PokemonListItem extends ConsumerWidget {
     final nonNullPoke = poke!;
 
     return ListTile(
-      leading: Container(
-        width: 80,
-        decoration: BoxDecoration(
-          color: (pokeTypeColors[nonNullPoke.types.first.type.name] ??
-                  Colors.grey[100])
-              ?.withOpacity(.3),
-          borderRadius: BorderRadius.circular(10),
-          image: DecorationImage(
-            fit: BoxFit.fitWidth,
-            image: NetworkImage(
-              nonNullPoke.sprites.other.officialArtwork.frontDefault,
+      leading: Hero(
+        tag: 'pokemon_${nonNullPoke.id}',
+        child: Container(
+          width: 80,
+          decoration: BoxDecoration(
+            color: (pokeTypeColors[nonNullPoke.types.first.type.name] ??
+                    Colors.grey[100])
+                ?.withOpacity(.3),
+            borderRadius: BorderRadius.circular(10),
+            image: DecorationImage(
+              fit: BoxFit.fitWidth,
+              image: NetworkImage(
+                nonNullPoke.sprites.other.officialArtwork.frontDefault,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
# 概要

- Hero Widgetを使用し一覧から詳細画面へ遷移時にアニメーションを行うように

# スクリーンショット (UI の追加、変更時に添付)

https://github.com/yyupyong/pokemon-app/assets/109585930/cc0f662d-c3b6-46d5-adfc-655c694e3012

# チェックリスト　

※ 実行したら x と記載し、当てはまらない場合は　 NA と記載する

- [x] Github 上でコードを確認して、コードが適切であることを確認した
- [x] Github 上でコードを確認して、不要な変更が含まれていないことを確認した
- [NA] 必要な箇所に `TODO`, `FIXME`を付けて、チケット ID を書いた
